### PR TITLE
Update AGP version to 8.8.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.10.0"
+agp = "8.8.2"
 kotlin = "2.0.0"
 coreKtx = "1.10.1"
 junit = "4.13.2"


### PR DESCRIPTION
## Summary
- bump AGP version in `gradle/libs.versions.toml` from `8.10.0` to `8.8.2`

## Testing
- `gradle wrapper --version` *(fails: missing environment or connectivity)*

------
https://chatgpt.com/codex/tasks/task_e_6841e15c11f48333bdbefc7fe676bf8c